### PR TITLE
Replace promkit with inquire crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crossterm"
-version = "0.23.2"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
@@ -55,10 +55,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "downcast-rs"
-version = "1.2.0"
+name = "dyn-clone"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "either"
@@ -67,10 +67,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
-name = "endian-type"
-version = "0.1.2"
+name = "inquire"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+checksum = "fd079157ad94a32f7511b2e13037f3ae417ad80a6a9b0de29154d48b86f5d6c8"
+dependencies = [
+ "bitflags",
+ "crossterm",
+ "dyn-clone",
+ "lazy_static",
+ "newline-converter",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-width",
+]
 
 [[package]]
 name = "itertools"
@@ -80,6 +90,12 @@ checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -125,19 +141,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "newline-converter"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f71d09d5c87634207f894c6b31b6a2b2c64ea3bdcf71bd5599fdbbe1600c00f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "ngrammatic"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c6f2f987e82da7fb8a290e959bba528638bc0e2629e38647591e845ecb5f6fe"
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "parking_lot"
@@ -163,26 +179,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "promkit"
-version = "0.1.2"
+name = "proc-macro2"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b452574647795434290b4737951dc4c2063ff4a9bf69e958ca234d8b44ec0a40"
+checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
 dependencies = [
- "crossterm",
- "downcast-rs",
- "radix_trie",
- "scopeguard",
- "unicode-width",
+ "unicode-ident",
 ]
 
 [[package]]
-name = "radix_trie"
-version = "0.2.1"
+name = "quote"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
- "endian-type",
- "nibble_vec",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -254,14 +265,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "syn"
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "thefug"
 version = "0.1.0"
 dependencies = [
+ "inquire",
  "itertools",
  "ngrammatic",
- "promkit",
  "regex",
 ]
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+inquire = "0" # https://github.com/mikaelmello/inquire
 itertools = "0" # https://github.com/rust-itertools/itertools
 ngrammatic = "0" # https://github.com/compenguy/ngrammatic
-promkit = "0" # https://github.com/ynqa/promkit
 regex = "1" # https://github.com/rust-lang/regex

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -5,6 +5,7 @@ pub struct Selector {
     commands: Vec<String>,
 }
 
+// TODO: Don't rely on a crate for this
 impl Selector {
     pub fn new(command: String, commands: Vec<String>) -> Self {
         Self { command, commands }

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -1,12 +1,4 @@
-use promkit::{
-    build::Builder,
-    crossterm::style,
-    register::Register,
-    select::{self, State},
-    selectbox::SelectBox,
-    Prompt,
-};
-use std::io::Error;
+use inquire::{error::InquireResult, Select};
 
 pub struct Selector {
     command: String,
@@ -18,20 +10,10 @@ impl Selector {
         Self { command, commands }
     }
 
-    pub fn show(&self) -> Result<String, Error> {
-        let mut selector = self.build_selector()?;
-        selector.run()
-    }
-
-    fn build_selector(&self) -> promkit::Result<Prompt<State>> {
-        let mut selectbox = Box::<SelectBox>::default();
-        selectbox.register_all(&self.commands);
-
+    pub fn show(&self) -> InquireResult<String> {
         let command = &self.command;
-        select::Builder::default()
-            .title(format!("The fug? ({command})"))
-            .title_color(style::Color::DarkGreen)
-            .selectbox(selectbox)
-            .build()
+        let commands = self.commands.clone();
+
+        Select::new(&format!("The fug? ({command})"), commands).prompt()
     }
 }


### PR DESCRIPTION
Promkit clears stdout when the select prompt comes up which is pretty annoying. Replacing with [inquire](https://github.com/mikaelmello/inquire)'s select prompt as it doesn't clear the prompt. Still likely I'll want to eventually write my own UI but for simplicity still going to rely on a crate even if I'm not using 90% of its features

<img width="727" alt="image" src="https://user-images.githubusercontent.com/13454550/227726239-6a8596f5-1cbc-4c2d-85d4-ec2ac49681d3.png">

After selection
<img width="532" alt="image" src="https://user-images.githubusercontent.com/13454550/227726277-a3a19487-c515-47dc-a611-02a73d0f182e.png">
